### PR TITLE
Send metadata1 and mfaType when logging in with root user using MFA

### DIFF
--- a/coto/clients/signin_aws/__init__.py
+++ b/coto/clients/signin_aws/__init__.py
@@ -222,6 +222,9 @@ class Client(BaseClient):
 
         if mfa_secret is not None:
             data['mfa1'] = TOTP(mfa_secret).now()
+            data['metadata1'] = self.session()._metadata1_generator.generate()
+            data['mfaType'] = 'OTP'
+
 
         # an exception is thrown if authentication was unsuccessful
         self._action('authenticateRoot', data, captcha_guess=captcha_guess)

--- a/coto/session/session.py
+++ b/coto/session/session.py
@@ -1,4 +1,4 @@
-from botocore.vendored import requests
+import requests
 import json
 from urllib.parse import unquote
 from colors import color

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author = "Sentia MPC B.V.",
     author_email = "info@sentia.com",
     license = "Apache",
-    version = "0.2.2",
+    version = "0.2.3",
     packages = find_packages(),
     install_requires = [
         'requests',


### PR DESCRIPTION
Without these two parameters I received the following exception when trying to log in with the root password and the virtual mfa:

Exception: failed action authenticateRoot: Your authentication information is incorrect. Please try again.